### PR TITLE
Rewrite feed to WordPress BE

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -27,4 +27,16 @@ module.exports = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      {
+        source: '/feed/',
+        destination: `https://${process.env.NEXT_PUBLIC_WP_API_DOMAIN}/feed/`,
+      },
+      {
+        source: '/feed/atom/',
+        destination: `https://${process.env.NEXT_PUBLIC_WP_API_DOMAIN}/feed/atom/`,
+      },
+    ];
+  },
 };


### PR DESCRIPTION
We can use the built-in WordPress feed for this (for now, at least).