### PR TITLE
Stop using deprecated `/blocks`

### DIFF
--- a/src/@ui/atoms/index.stories.mdx
+++ b/src/@ui/atoms/index.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { Blockquote } from './Blockquote';
 import { Ul, Ol, Li } from './lists';
 

--- a/src/@ui/box/index.stories.mdx
+++ b/src/@ui/box/index.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { Body } from '@ui/typography';
 import { Article } from './Article';
 import { Main } from './Main';

--- a/src/@ui/theme/index.stories.mdx
+++ b/src/@ui/theme/index.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { PrimaryHeading } from './PrimaryHeading';
 import { SecondaryHeading } from './SecondaryHeading';
 import { Icon } from './Icon';

--- a/src/@ui/typography/index.stories.mdx
+++ b/src/@ui/typography/index.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { Heading } from './Heading';
 import { Body } from './Body';
 import { Link } from './inline';


### PR DESCRIPTION
We can import this directly.