### PR TITLE
Fix default branch for TinaCMS

### DIFF
--- a/.tina/config.js
+++ b/.tina/config.js
@@ -14,8 +14,7 @@ import {
   tagCollection,
 } from './collections';
 
-const branch =
-  process.env.HEAD || process.env.VERCEL_GIT_COMMIT_REF || 'migrate-to-tinacms'; // TODO point to master/main
+const branch = process.env.HEAD || process.env.VERCEL_GIT_COMMIT_REF || 'main';
 
 export default defineConfig({
   branch,


### PR DESCRIPTION
No longer need to use the migrate side branch.