### PR TITLE
Fix reading times

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@tinacms/mdx": "^1.0.4",
         "classcat": "^5.0.4",
         "date-fns": "^2.29.2",
+        "date-fns-tz": "^2.0.0",
         "feed": "^4.2.2",
         "htmlparser2": "^8.0.1",
         "multer": "^1.4.5-lts.1",
@@ -24356,6 +24357,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
+      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/date-format": {
@@ -68812,6 +68821,12 @@
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
       "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+    },
+    "date-fns-tz": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
+      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+      "requires": {}
     },
     "date-format": {
       "version": "4.0.14",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tinacms/mdx": "^1.0.4",
     "classcat": "^5.0.4",
     "date-fns": "^2.29.2",
+    "date-fns-tz": "^2.0.0",
     "feed": "^4.2.2",
     "htmlparser2": "^8.0.1",
     "multer": "^1.4.5-lts.1",

--- a/src/@reading/server.js
+++ b/src/@reading/server.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
-import { subDays, endOfDay, format, parseISO } from 'date-fns';
+import { subDays, endOfDay, format, parseISO, addDays } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 import { server } from '@app/config';
 
 export const getReadingProps = async displayDays => {
@@ -13,8 +14,8 @@ export const getReadingProps = async displayDays => {
       `${server.READING_API_HOST}/api/articles`,
       {
         params: {
-          read_at_lte: format(endOfDay(targetDay), 'yyyy-MM-dd'),
-          read_at_gt: format(endOfDay(subDays(targetDay, 1)), 'yyyy-MM-dd'),
+          read_at_lte: format(addDays(endOfDay(targetDay), 1), 'yyyy-MM-dd'),
+          read_at_gt: format(endOfDay(targetDay), 'yyyy-MM-dd'),
         },
       },
     );
@@ -26,7 +27,11 @@ export const getReadingProps = async displayDays => {
           id: `link-${link.id}`,
           title: link.title,
           url: link.url,
-          readAt: format(parseISO(link.read_at), 'hh:mm a'),
+          readAt: formatInTimeZone(
+            parseISO(link.read_at),
+            'America/New_York',
+            'hh:mm a',
+          ),
         })),
       });
     }


### PR DESCRIPTION
This is still not great because the reading API is assuming the read_at dates are NY times, rather than sending it, but this will suffice for now.