### PR TITLE
Expand the number of open PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: daily
       time: '10:00'
       timezone: America/New_York
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 10
     groups:
       storybook:
         patterns:


### PR DESCRIPTION
Bump to 10 so we can keep everything updated more regularly.