### PR TITLE
Fix the resume's print output and screen layout

### DIFF
--- a/src/@ui/box/Main.js
+++ b/src/@ui/box/Main.js
@@ -1,5 +1,16 @@
-export const Main = ({ children }) => (
-  <main className="print:pt-0 print:mx-0 print:max-w-full max-w-lg p-5">
+import cc from 'classcat';
+
+export const Main = ({ children, wide = false }) => (
+  <main
+    className={cc([
+      'print:pt-0',
+      'print:mx-0',
+      'print:px-0',
+      'print:max-w-full',
+      'p-5',
+      wide ? 'max-w-full' : 'max-w-lg',
+    ])}
+  >
     {children}
   </main>
 );

--- a/src/@ui/layout/Layout.js
+++ b/src/@ui/layout/Layout.js
@@ -43,6 +43,7 @@ export const Layout = ({ layoutP, children }) => {
       className={cc([
         'relative',
         'grid',
+        'print:block',
         'transition-grid-cols',
         'duration-1000',
         'ease-[cubic-bezier(.36,.15,.44,1.25)]',
@@ -61,6 +62,7 @@ export const Layout = ({ layoutP, children }) => {
           'lg:top-0',
           'lg:h-screen',
           'lg:overflow-hidden',
+          'print:hidden',
         ])}
       >
         {layout !== 'headerless' && (
@@ -77,6 +79,8 @@ export const Layout = ({ layoutP, children }) => {
           'right-0',
           'bottom-0',
           'overflow-y-auto',
+          'print:static',
+          'print:overflow-visible',
           {
             'left-0': !fullScreen,
             'lg:left-[352px]': !fullScreen && layout !== 'headerless',

--- a/src/@ui/resume/index.js
+++ b/src/@ui/resume/index.js
@@ -4,24 +4,40 @@ import cc from 'classcat';
 const h1Class = cc([
   'font-muli',
   'text-4xl',
+  'print:text-2xl',
+  'print:leading-none',
   'py-1',
   'mb-2',
   'print:mb-1',
   'print:py-0',
 ]);
-const h2Class = cc(['font-ovo', 'text-base', 'py-1', 'mb-1']);
+const h2Class = cc(['font-ovo', 'text-base', 'py-1', 'print:py-0', 'mb-1']);
 
-const expH3Class = cc(['font-muli', 'text-center', 'py-1']);
-const expH4Class = cc(['font-muli', 'text-lg', 'py-1', 'print:text-md']);
-const expH5Class = cc(['font-ovo', 'text-base', 'py-1', 'print:text-sm']);
+const expH3Class = cc(['font-muli', 'text-center', 'py-1', 'print:py-2']);
+const expH4Class = cc([
+  'font-muli',
+  'text-lg',
+  'py-1',
+  'print:py-0',
+  'print:text-base',
+]);
+const expH5Class = cc([
+  'font-ovo',
+  'font-bold',
+  'text-base',
+  'py-1',
+  'print:py-0',
+  'print:text-sm',
+]);
 const expLiClass = cc(['font-ovo', 'text-base', 'mb-1', 'print:text-sm']);
 
 const sidebarH3Class = cc([
   'font-muli',
   'text-lg',
+  'print:text-base',
   'text-center',
   'py-3',
-  'print:py-0',
+  'print:py-2',
 ]);
 const sidebarH4Class = cc([
   'font-ovo',
@@ -30,8 +46,14 @@ const sidebarH4Class = cc([
   'py-1',
   'print:py-0',
 ]);
-const sidebarLiClass = cc(['font-ovo', 'text-sm', 'py-1', 'ml-1']);
-const sidebarSubLiClass = cc(['font-ovo', 'text-xs', 'py-1']);
+const sidebarLiClass = cc([
+  'font-ovo',
+  'text-sm',
+  'py-1',
+  'print:py-0',
+  'ml-1',
+]);
+const sidebarSubLiClass = cc(['font-ovo', 'text-xs', 'py-1', 'print:py-0']);
 
 const ExpLi = ({ children }) => <li className={expLiClass}>{children}</li>;
 
@@ -51,9 +73,9 @@ const Experience = ({ experiences }) => (
             )}
           </h4>
           {exp.positions.map(({ title, start, end, responsibilities }, key) => (
-            <div className="mb-3" key={key}>
+            <div className={cc(['mb-3', 'print:avoid-break-inside'])} key={key}>
               <h5 className={expH5Class}>{title}</h5>
-              <div className="font-ovo text-base mb-3">
+              <div className="font-ovo text-base print:text-xs mb-3">
                 {start} to {end ?? 'Present'}
               </div>
               <ul className="list-disc pl-5">
@@ -100,16 +122,19 @@ const SidebarSubLi = ({ children }) => (
   <li className={sidebarSubLiClass}>{children}</li>
 );
 
-const ExternalLink = ({ href, children }) => (
-  <a
-    href={href}
-    rel="noopener noreferrer"
-    target="_blank"
-    className="print:no-underline"
-  >
-    {children}
-  </a>
-);
+const ExternalLink = ({ href, children }) =>
+  href ? (
+    <a
+      href={href}
+      rel="noopener noreferrer"
+      target="_blank"
+      className="print:no-underline"
+    >
+      {children}
+    </a>
+  ) : (
+    children
+  );
 
 const SidebarItem = ({ children, className = '' }) => (
   <div
@@ -157,27 +182,28 @@ Projects.propTypes = {
   projects: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string.isRequired,
-      url: PropTypes.string.isRequired,
+      url: PropTypes.string,
       role: PropTypes.string.isRequired,
       highlights: PropTypes.arrayOf(PropTypes.string).isRequired,
     }),
   ).isRequired,
 };
 
-const Talks = ({ talks }) => (
-  <SidebarItem>
-    <SidebarH3>Talks</SidebarH3>
-    <SidebarUl>
-      {talks.map(({ name, url }, key) => (
-        <SidebarLi key={key}>
-          <SidebarH4 className="print:text-xs">
-            <ExternalLink href={url}>{name}</ExternalLink>
-          </SidebarH4>
-        </SidebarLi>
-      ))}
-    </SidebarUl>
-  </SidebarItem>
-);
+const Talks = ({ talks }) =>
+  talks.length === 0 ? null : (
+    <SidebarItem>
+      <SidebarH3>Talks</SidebarH3>
+      <SidebarUl>
+        {talks.map(({ name, url }, key) => (
+          <SidebarLi key={key}>
+            <SidebarH4 className="print:text-xs">
+              <ExternalLink href={url}>{name}</ExternalLink>
+            </SidebarH4>
+          </SidebarLi>
+        ))}
+      </SidebarUl>
+    </SidebarItem>
+  );
 
 Talks.propTypes = {
   talks: PropTypes.arrayOf(
@@ -271,13 +297,13 @@ export const Resume = ({
   skills,
 }) => (
   <div className="mx-4 pt-5 print:pt-0 print:mx-0 print:max-w-full">
-    <div className="bg-primary text-2xl print:text-base">
-      <div className="mx-auto text-center mb-2">
+    <div className="bg-primary print:bg-white text-2xl print:text-base">
+      <div className="mx-auto text-center mb-2 print:mb-0">
         <h1 className={h1Class}>{name}</h1>
         <h2 className={h2Class}>{location}</h2>
         <p className="text-sm font-ovo">{description}</p>
       </div>
-      <div className="mx-auto px-4 print:mx-2 flex max-w-2xl flex-col xl:flex-row pb-2">
+      <div className="mx-auto px-4 print:mx-0 print:px-2 flex max-w-2xl flex-col xl:flex-row pb-2">
         <div className="grow basis-full">
           <Experience experiences={experiences} />
         </div>

--- a/src/@vault/page.js
+++ b/src/@vault/page.js
@@ -152,7 +152,7 @@ export const VaultPage = async ({ content, frontmatter, source }) => {
           <TalkServer source={source} />
         </Suspense>
       ) : (
-        <Main>
+        <Main wide={frontmatter.web.slug === 'resume'}>
           {frontmatter.essay ? (
             <EssayHeader
               featuredMedia={frontmatter.essay?.featuredMedia}

--- a/src/@vault/server.js
+++ b/src/@vault/server.js
@@ -65,7 +65,7 @@ const DataEmbedBefore = ({ data }) => {
           role: project.roles.join(', '),
           highlights: project.highlights,
         }))}
-        talks={resume.publications.map(pub => ({
+        talks={(resume.publications ?? []).map(pub => ({
           name: pub.name,
           url: pub.url,
         }))}
@@ -197,7 +197,7 @@ export const compile = (/** @type {string} */ source) =>
         </thead>
       ),
       tbody: ({ children }) => (
-        <tbody className={cc(['mb-5', 'font-muli', 'text-md', 'text-left'])}>
+        <tbody className={cc(['mb-5', 'font-muli', 'text-base', 'text-left'])}>
           {children}
         </tbody>
       ),

--- a/src/index.css
+++ b/src/index.css
@@ -72,6 +72,13 @@
   break-inside: avoid;
 }
 
+/* Chrome defaults to a 0.4in margin all round, which wastes most of an inch
+   of line length on the resume. 0.25in stays inside the unprintable edge of
+   every common consumer printer. */
+@page {
+  margin: 0.25in;
+}
+
 @layer utilities {
   /**
  * Here you would add any custom utilities you need that don't come out of the
@@ -87,7 +94,7 @@
   }
 
   body {
-    @apply bg-primary;
+    @apply bg-primary print:bg-white;
   }
 }
 

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -35,6 +35,7 @@ module.exports = {
       montserrat: ['var(--font-montserrat)', ...fontFamily.sans],
     },
     fontSize: {
+      xs: '.75rem', // 12px
       sm: '.875rem', // 14px
       base: '1rem', // 16px
       lg: '1.125rem', // 18px


### PR DESCRIPTION
`/resume/` has been printing as a single truncated page since #1741 moved the content container to a `fixed`, natively-scrolling box. A fixed element is laid out against one viewport-height box when printing and its overflow is clipped rather than paginated, so Chrome renders page one and discards the rest — the resume cut off mid-2024 at Ollie Pets.

**1 truncated page → 3 complete pages.**

## Layout

Returning the container to normal flow under print fixes the truncation. The grid is dropped alongside it (its `100vw` track is meaningless on paper), and the nav column is hidden — a US Letter page is ~816px wide, so `lg:` matches in print and the column was reserving a screen-height block. That also removes the hamburger button that was printing in the top-left corner, since both it and the slide-in menu are its descendants. The cream background is dropped on both `body` and the resume wrapper.

## Type scale

Three classes compiled to nothing, so the print styles read as intentional while doing less than they claimed. Two different bugs:

- `text-xs` was **orphaned** — `xs` was dropped from the `fontSize` theme in 389395d (2021), leaving the sidebar sub-bullets pointing at a scale entry that no longer existed. Restored to `.75rem`.
- `text-md` was **never valid** — `md` has never existed in this scale, and Tailwind has no such step. Both usages now point at `base`: `print:text-md` on the experience headings, and `text-md` on vault table bodies (which pairs with `thead`'s `text-xl`).

## Print layout tuning

Margins were costing most of an inch of line length per side — Chrome's default 0.4in page margin plus `Main`'s horizontal padding, which had `print:pt-0` and `print:mx-0` but nothing overriding `px`. Now `@page { margin: 0.25in }` throughout, which stays inside the unprintable edge of common consumer printers.

| | Before | After |
|---|---|---|
| Side margins | 0.71in | 0.33in |
| Text column | 7.05in | 7.84in |

Sizing: name 40px → 24px, dates 16px → 12px, sidebar headings 18px → 16px, company names 18px → 16px. Vertical padding that only earned its keep on screen is stripped under print, and the h1 gets `leading-none` so page 1's top aligns with the others.

Section headings use symmetric `print:py-2` rather than margins, so their spacing can't collapse unevenly against whatever precedes them. Verified against the PDF's own text positions — all four now sit at 10.3–10.6pt above.

Job titles are bolded (screen and print); they had been the same weight as the bullets they head.

## Page breaks

`print:avoid-break-inside` is applied to the **position** block — title, dates, and bullets — not the company block. A long tenure spans several titles and can't be expected to fit on one page, but a title orphaned from its bullets is a formatting bug. Every break now falls on a position boundary.

## Full-width on screen

Separate commit. The resume's sidebar sits beside the experience column above 992px, but `Main` caps every vault page at 50rem, so both columns were squeezed into 800px regardless of window width, leaving the rest of the content area empty. `Main` takes a `wide` prop, set for the resume via its slug — it's a one-off rather than a category, and the vault is Obsidian-synced, so a repo-side frontmatter flag would be clobbered by the next push.

The `xl:` breakpoint is unchanged, so where two columns appear is exactly as before; they just get ~1088px at 1440px wide instead of 800px.

## Empty Talks

The publications list is expected to empty out, so `Talks` renders nothing when there is nothing to show, and `resume.publications` going missing entirely is tolerated rather than throwing on `.map`.

## Verification

Printed via headless Chrome against `npm run dev` at every step, with margins and heading gaps measured from the rendered pages and from `pdftotext -bbox` output rather than inferred from the classes. Screen layout checked by screenshot at 1024/1200/1440/1600 against the deployed site. The empty-Talks case was verified by removing the `publications:` key and re-rendering against a cleared `.next`.

Note that `getData` is `'use cache'` with `cacheLife('max')`, so testing a vault data change requires clearing `.next` first; a stale cache initially made a working guard look broken.

`npm test` passes.

Screen rendering is unaffected apart from three deliberate changes: bolded job titles, the vault table body going from inherited size to an explicit `1rem`, and the resume's width cap. Note `@page` is global, so the new margins apply to every printed page on the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)