### PR TITLE
Commit the agent rules block next dev generates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,3 +106,13 @@ open a pull request.
 Always run `npm test` before committing and fix any failures before proceeding.
 
 Follow the Linus Torvalds style for git commit messages: subject line under 50 characters in imperative mood, blank line, then a prose body with lines wrapped at 72 characters that explains the *why* rather than just restating the diff. No bullet points. The 72-character line wrap applies to commit messages only, not to other files.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->


### PR DESCRIPTION
`next dev` writes a `nextjs-agent-rules` block into `CLAUDE.md` on every start. Leaving it uncommitted means every working tree carries a permanent spurious modification that has to be stashed or worked around; reverting it accomplishes nothing, since the next `npm run dev` puts it straight back.

Committing it keeps the tree clean and version-controls the guidance alongside the Next version it describes. The content is byte-exact as generated — I let the dev server write it rather than hand-copying.

Generator: `node_modules/next/dist/server/lib/generate-agent-files.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)