### PR TITLE
Group CSS toolchain updates in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,15 @@
   "commitBodyTable": true,
   "extends": ["config:recommended"],
   "timezone": "America/New_York",
-  "schedule": ["after 10am and before 11am"]
+  "schedule": ["after 10am and before 11am"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["lightningcss", "lightningcss-**"],
+      "groupName": "lightningcss"
+    },
+    {
+      "matchPackageNames": ["tailwindcss", "@tailwindcss/**"],
+      "groupName": "tailwindcss"
+    }
+  ]
 }


### PR DESCRIPTION
Adds two Renovate `packageRules` groups so the platform-specific native binaries stop opening one PR each.

**`lightningcss`** — matches `lightningcss` and `lightningcss-**`. Three direct deps today (`lightningcss-linux-arm64-musl`, `-linux-x64-gnu`, `-linux-x64-musl`, all in `optionalDependencies`); the root package and the darwin/win32/android/freebsd variants are transitive and only move in the lockfile, but the pattern covers the root in case it ever becomes direct.

**`tailwindcss`** — matches `tailwindcss` and `@tailwindcss/**`, so `tailwindcss`, `@tailwindcss/postcss`, and the three `@tailwindcss/oxide-linux-*` binaries land together. These are supposed to be version-locked to each other. The exact match on `tailwindcss` keeps `tailwindcss-view-transitions` (unrelated plugin, 0.1.x) out of the group.

Two groups rather than one because lightningcss is on a 1.x line and Tailwind on 4.x — their releases don't coincide, and a shared group would make each PR wait on the other.

Verified with `npx renovate-config-validator renovate.json`. `npm test` passes.

Note: this doesn't retroactively fix existing drift — the oxide binaries sit at `^4.0.1` while core is at `^4.1.17`. The group only takes effect on the next 4.x release. Happy to bump those ranges in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)