### PR TITLE
Float footnotes into the margin, Tufte-style

### DIFF
--- a/src/@ui/box/Main.js
+++ b/src/@ui/box/Main.js
@@ -1,5 +1,8 @@
 import cc from 'classcat';
 
+// The margin-note rules in `src/index.css` select on `margin-notes` and do
+// arithmetic off this column's width and padding — changing either means
+// changing the numbers there.
 export const Main = ({ children, wide = false }) => (
   <main
     className={cc([
@@ -8,7 +11,7 @@ export const Main = ({ children, wide = false }) => (
       'print:px-0',
       'print:max-w-full',
       'p-5',
-      wide ? 'max-w-full' : 'max-w-lg',
+      wide ? 'max-w-full' : ['max-w-lg', 'margin-notes'],
     ])}
   >
     {children}

--- a/src/@ui/layout/Layout.js
+++ b/src/@ui/layout/Layout.js
@@ -74,6 +74,11 @@ export const Layout = ({ layoutP, children }) => {
       <div
         className={cc([
           'vt-name-[content]',
+          // Margin notes size off this column, since the 352px nav makes
+          // viewport breakpoints lie about the space left. Note this makes the
+          // div a containing block for `position: fixed` descendants — see the
+          // Layout Gotchas in CLAUDE.md.
+          '@container',
           'fixed',
           'top-0',
           'right-0',

--- a/src/@ui/typography/inline.js
+++ b/src/@ui/typography/inline.js
@@ -69,9 +69,14 @@ const linkClass = cc([
   'transition-colors',
 ]);
 
-export const Link = ({ children, href, title }) => {
+export const Link = ({ children, href, title, tabIndex }) => {
   return (
-    <NextLink href={href} className={linkClass} title={title}>
+    <NextLink
+      href={href}
+      className={linkClass}
+      title={title}
+      tabIndex={tabIndex}
+    >
       {children}
     </NextLink>
   );

--- a/src/@vault/rehype-margin-notes.js
+++ b/src/@vault/rehype-margin-notes.js
@@ -1,0 +1,265 @@
+/**
+ * @typedef {import('hast').Element} Element
+ * @typedef {import('hast').ElementContent} ElementContent
+ * @typedef {import('hast').Root} Root
+ */
+
+/** @type {(node: unknown, tagName: string) => node is Element} */
+const isElement = (node, tagName) =>
+  typeof node === 'object' &&
+  node !== null &&
+  /** @type {Element} */ (node).type === 'element' &&
+  /** @type {Element} */ (node).tagName === tagName;
+
+/** Hast nodes are plain JSON, and jsdom lacks `structuredClone` under Jest.
+ * @type {<T>(nodes: T) => T} */
+const clone = nodes => JSON.parse(JSON.stringify(nodes));
+
+/** @type {(node: ElementContent) => boolean} */
+const isBlankText = node => node.type === 'text' && node.value.trim() === '';
+
+/**
+ * Phrasing content markdown can produce. The copy is spliced into the article's
+ * `<p>`, and the parser closes a `<p>` at the first block-level start tag inside
+ * it, restructuring the DOM out from under React.
+ *
+ * `img` is excluded despite being phrasing content: MDX maps it to
+ * `ServerEmbed`, which can render a whole tweet card.
+ */
+const PHRASING = new Set([
+  'a',
+  'abbr',
+  'b',
+  'bdi',
+  'bdo',
+  'br',
+  'cite',
+  'code',
+  'data',
+  'del',
+  'dfn',
+  'em',
+  'i',
+  'input',
+  'ins',
+  'kbd',
+  'mark',
+  'picture',
+  'q',
+  'ruby',
+  's',
+  'samp',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'sup',
+  'time',
+  'u',
+  'var',
+  'wbr',
+]);
+
+/**
+ * `unist-util-visit` in miniature, to avoid promoting a transitive package to a
+ * direct dependency. Recurses through every node with children, not just
+ * elements, so a footnote inside an MDX component is still found. The visitor
+ * returns how many nodes it spliced in so the walk skips them.
+ *
+ * @type {(
+ *  node: unknown,
+ *  visit: (node: Element, index: number, parent: any) => number | void,
+ * ) => void}
+ */
+const eachElement = (node, visit) => {
+  const children = /** @type {{ children?: unknown[] }} */ (node)?.children;
+  if (!Array.isArray(children)) return;
+
+  for (let index = 0; index < children.length; index++) {
+    const child = children[index];
+    if (/** @type {{ type?: string }} */ (child)?.type === 'element') {
+      index += visit(/** @type {Element} */ (child), index, node) ?? 0;
+    }
+    eachElement(child, visit);
+  }
+};
+
+/**
+ * Collects the footnote sections and, per section, the `<li>` bodies keyed by
+ * id. The sections are left alone until we know whether every note in them made
+ * it into the margin.
+ *
+ * @type {(tree: Root) => { section: Element, notes: Record<string, ElementContent[]> }[]}
+ */
+const collectSections = tree => {
+  /** @type {{ section: Element, notes: Record<string, ElementContent[]> }[]} */
+  const sections = [];
+
+  eachElement(tree, node => {
+    if (node.tagName !== 'section' || !node.properties.dataFootnotes) return;
+
+    /** @type {Record<string, ElementContent[]>} */
+    const notes = {};
+    eachElement(node, item => {
+      if (item.tagName === 'li' && typeof item.properties.id === 'string') {
+        notes[item.properties.id] = item.children;
+      }
+    });
+    sections.push({ section: node, notes });
+  });
+
+  return sections;
+};
+
+/**
+ * Node types safe inside a `<p>`; `element` is checked against `PHRASING`
+ * instead. `raw` and every MDX node are rejected — a JSX tag name says nothing
+ * about what it renders, and `RecentEssays` in a note body is a `<ul>`.
+ */
+const PHRASING_TYPES = new Set(['text', 'comment']);
+
+/** @type {(node: ElementContent) => boolean} */
+const isPhrasing = node =>
+  node.type === 'element'
+    ? PHRASING.has(node.tagName) && node.children.every(isPhrasing)
+    : PHRASING_TYPES.has(node.type);
+
+/**
+ * A focusable element inside an `aria-hidden` subtree is an accessibility
+ * violation, but the copy is the note's only visible rendering once the real
+ * section is clipped, so its links must stay clickable and selectable.
+ * `tabIndex: -1` drops the tab stop; `inert` would drop those too.
+ *
+ * @type {(node: ElementContent) => void}
+ */
+const deactivateLinks = node => {
+  if (node.type !== 'element') return;
+  if (node.tagName === 'a') node.properties.tabIndex = -1;
+  node.children.forEach(deactivateLinks);
+};
+
+/**
+ * Turns a footnote `<li>` body into content legal inside the article's `<p>`:
+ * wrapping `<p>`s are unwrapped, consecutive ones joined by a `<br>`, and the
+ * `↩` backref dropped, since the copy has nowhere to go back to.
+ *
+ * Returns `null` if the body holds anything that is not phrasing content.
+ *
+ * @type {(children: ElementContent[]) => ElementContent[] | null}
+ */
+const toMarginBody = children => {
+  /** @type {ElementContent[]} */
+  const body = [];
+
+  // Validate before cloning, never up front: an MDX expression carries an
+  // `estree` in `data`, which is not plain JSON and can throw on deep copy.
+  for (const child of children) {
+    if (isBlankText(child)) continue;
+    if (!isElement(child, 'p') && !isPhrasing(child)) return null;
+
+    if (body.length > 0) {
+      body.push({
+        type: 'element',
+        tagName: 'br',
+        properties: {},
+        children: [],
+      });
+    }
+
+    for (const node of isElement(child, 'p') ? child.children : [child]) {
+      if (!isPhrasing(node)) return null;
+      // The backref's value is the empty string, so test for the key itself.
+      if (node.type === 'element' && 'dataFootnoteBackref' in node.properties) {
+        continue;
+      }
+      if (body.length === 0 && isBlankText(node)) continue;
+      body.push(clone(node));
+    }
+  }
+
+  // Dropping the backref leaves the space that separated it from the text.
+  while (body.length > 0) {
+    const last = body[body.length - 1];
+    if (isBlankText(last) || isElement(last, 'br')) {
+      body.pop();
+      continue;
+    }
+    if (last.type === 'text') last.value = last.value.replace(/\s+$/, '');
+    break;
+  }
+
+  body.forEach(deactivateLinks);
+
+  return body;
+};
+
+/**
+ * Splices a decorative copy of every footnote in next to its reference so CSS
+ * can float it into the right margin, Tufte-style. The copy carries no ids and
+ * is `aria-hidden`, leaving `<section data-footnotes>` the single copy in the
+ * accessibility tree and the narrow-screen fallback.
+ *
+ * A section whose notes all made it into the margin is stamped
+ * `data-margin-notes="all"`, which is what the CSS keys the clipping off.
+ * Clipping a section holding a refused note would leave it with no visual
+ * representation at all, so that section stays visible instead.
+ *
+ * @type {() => (tree: Root) => void}
+ */
+export const rehypeMarginNotes = () => tree => {
+  const sections = collectSections(tree);
+  if (sections.length === 0) return;
+
+  /** @type {Record<string, ElementContent[]>} */
+  const notes = Object.assign({}, ...sections.map(({ notes }) => notes));
+  if (Object.keys(notes).length === 0) return;
+
+  /** One note, one margin copy: a footnote referenced twice would otherwise
+   * stack two identical notes. Later references stay plain superscripts. */
+  const spliced = new Set();
+
+  eachElement(tree, (node, index, parent) => {
+    if (node.tagName !== 'sup') return;
+
+    const ref = node.children.find(
+      child => child.type === 'element' && child.properties.dataFootnoteRef,
+    );
+    if (!isElement(ref, 'a') || typeof ref.properties.href !== 'string') return;
+
+    const id = ref.properties.href.replace(/^#/, '');
+    if (spliced.has(id)) return;
+
+    const note = notes[id];
+    if (!note) return;
+
+    const body = toMarginBody(note);
+    if (!body) return;
+
+    spliced.add(id);
+
+    parent.children.splice(index + 1, 0, {
+      type: 'element',
+      tagName: 'span',
+      properties: { className: ['margin-note'], ariaHidden: 'true' },
+      children: [
+        {
+          type: 'element',
+          tagName: 'span',
+          properties: { className: ['margin-note-number'] },
+          children: clone(ref.children),
+        },
+        { type: 'text', value: ' ' },
+        ...body,
+      ],
+    });
+
+    return 1;
+  });
+
+  for (const { section, notes } of sections) {
+    const ids = Object.keys(notes);
+    if (ids.length > 0 && ids.every(id => spliced.has(id))) {
+      section.properties.dataMarginNotes = 'all';
+    }
+  }
+};

--- a/src/@vault/rehype-margin-notes.test.js
+++ b/src/@vault/rehype-margin-notes.test.js
@@ -1,0 +1,248 @@
+import { rehypeMarginNotes } from './rehype-margin-notes';
+
+const el = (tagName, properties, children = []) => ({
+  type: 'element',
+  tagName,
+  properties,
+  children,
+});
+
+const text = value => ({ type: 'text', value });
+
+/** The shape remark-gfm produces for `Body.[^1]` plus its definition. */
+const fixture = () => ({
+  type: 'root',
+  children: [
+    el('p', {}, [
+      text('Body.'),
+      el('sup', {}, [
+        el(
+          'a',
+          {
+            href: '#user-content-fn-1',
+            id: 'user-content-fnref-1',
+            dataFootnoteRef: true,
+            ariaDescribedBy: 'footnote-label',
+          },
+          [text('1')],
+        ),
+      ]),
+      text(' More body.'),
+    ]),
+    el('section', { dataFootnotes: true, className: ['footnotes'] }, [
+      el('h2', { id: 'footnote-label' }, [text('Footnotes')]),
+      el('ol', {}, [
+        el('li', { id: 'user-content-fn-1' }, [
+          text('\n'),
+          el('p', {}, [
+            text('The note with a '),
+            el('a', { href: 'https://example.com' }, [text('link')]),
+            text('. '),
+            el(
+              'a',
+              {
+                href: '#user-content-fnref-1',
+                dataFootnoteBackref: '',
+                className: ['data-footnote-backref'],
+              },
+              [text('↩')],
+            ),
+          ]),
+          text('\n'),
+        ]),
+      ]),
+    ]),
+  ],
+});
+
+const run = tree => {
+  rehypeMarginNotes()(tree);
+  return tree;
+};
+
+const flatten = node =>
+  node.type === 'text'
+    ? node.value
+    : (node.children ?? []).map(flatten).join('');
+
+describe('rehypeMarginNotes', () => {
+  it('splices a decorative copy in right after the reference', () => {
+    const [paragraph] = run(fixture()).children;
+
+    expect(paragraph.children.map(child => child.tagName)).toEqual([
+      undefined,
+      'sup',
+      'span',
+      undefined,
+    ]);
+
+    const note = paragraph.children[2];
+    expect(note.properties).toEqual({
+      className: ['margin-note'],
+      ariaHidden: 'true',
+    });
+    expect(flatten(note)).toBe('1 The note with a link.');
+  });
+
+  it('keeps the copied links clickable but out of the tab order', () => {
+    const note = run(fixture()).children[0].children[2];
+    const link = note.children.find(child => child.tagName === 'a');
+
+    expect(link.properties.href).toBe('https://example.com');
+    expect(link.properties.tabIndex).toBe(-1);
+  });
+
+  it('repeats the reference number in the margin copy', () => {
+    const note = run(fixture()).children[0].children[2];
+    const [number] = note.children;
+
+    expect(number.properties.className).toEqual(['margin-note-number']);
+    expect(flatten(number)).toBe('1');
+  });
+
+  it('unwraps the note body so no <p> nests inside the article <p>', () => {
+    const note = run(fixture()).children[0].children[2];
+
+    expect(note.children.some(child => child.tagName === 'p')).toBe(false);
+  });
+
+  it('gives the copy no ids and drops the backref', () => {
+    const note = run(fixture()).children[0].children[2];
+    const ids = [];
+    const backrefs = [];
+    const walk = node => {
+      if (node.properties?.id) ids.push(node.properties.id);
+      if (node.properties && 'dataFootnoteBackref' in node.properties) {
+        backrefs.push(node);
+      }
+      (node.children ?? []).forEach(walk);
+    };
+    walk(note);
+
+    expect(ids).toEqual([]);
+    expect(backrefs).toEqual([]);
+  });
+
+  it('leaves the footnotes section intact apart from the marker', () => {
+    const tree = fixture();
+    const before = JSON.stringify(tree.children[1]);
+    run(tree);
+
+    const section = tree.children[1];
+    expect(section.properties.dataMarginNotes).toBe('all');
+    delete section.properties.dataMarginNotes;
+    expect(JSON.stringify(section)).toBe(before);
+  });
+
+  it('leaves the section unmarked when a note could not be copied', () => {
+    const tree = withNoteBody([el('ul', {}, [el('li', {}, [text('one')])])]);
+    run(tree);
+
+    expect('dataMarginNotes' in tree.children[1].properties).toBe(false);
+  });
+
+  it('finds references nested inside MDX JSX elements', () => {
+    const tree = fixture();
+    const [paragraph] = tree.children;
+    tree.children[0] = {
+      type: 'mdxJsxFlowElement',
+      name: 'Callout',
+      attributes: [],
+      children: [paragraph],
+    };
+    run(tree);
+
+    const notes = paragraph.children.filter(
+      child => child.properties?.className?.[0] === 'margin-note',
+    );
+    expect(notes).toHaveLength(1);
+  });
+
+  /** Replaces the `<li>` body with `children`, keeping the rest of the shape. */
+  const withNoteBody = children => {
+    const tree = fixture();
+    tree.children[1].children[1].children[0].children = children;
+    return tree;
+  };
+
+  const ref = number =>
+    el('sup', {}, [
+      el('a', { href: `#user-content-fn-${number}`, dataFootnoteRef: true }, [
+        text(String(number)),
+      ]),
+    ]);
+
+  it('separates multiple paragraphs so the sentences do not run together', () => {
+    const tree = withNoteBody([
+      el('p', {}, [text('Para one.')]),
+      text('\n'),
+      el('p', {}, [text('Para two.')]),
+    ]);
+    const note = run(tree).children[0].children[2];
+
+    expect(note.children.some(child => child.tagName === 'br')).toBe(true);
+    expect(flatten(note)).toBe('1 Para one.Para two.');
+  });
+
+  it('skips notes whose body is not phrasing content', () => {
+    const tree = withNoteBody([
+      el('p', {}, [text('Intro.')]),
+      el('ul', {}, [el('li', {}, [text('one')])]),
+    ]);
+    const [paragraph] = run(tree).children;
+
+    expect(paragraph.children.map(child => child.tagName)).toEqual([
+      undefined,
+      'sup',
+      undefined,
+    ]);
+  });
+
+  it('skips notes holding a block element nested in a paragraph', () => {
+    const tree = withNoteBody([
+      el('p', {}, [el('pre', {}, [el('code', {}, [text('x')])])]),
+    ]);
+    const [paragraph] = run(tree).children;
+
+    expect(paragraph.children.some(child => child.tagName === 'span')).toBe(
+      false,
+    );
+  });
+
+  it('skips notes holding an MDX component, which may render a block', () => {
+    const tree = withNoteBody([
+      {
+        type: 'mdxJsxFlowElement',
+        name: 'RecentEssays',
+        attributes: [],
+        children: [],
+      },
+    ]);
+    const [paragraph] = run(tree).children;
+
+    expect(paragraph.children.some(child => child.tagName === 'span')).toBe(
+      false,
+    );
+    expect('dataMarginNotes' in tree.children[1].properties).toBe(false);
+  });
+
+  it('splices one copy for a footnote referenced more than once', () => {
+    const tree = fixture();
+    tree.children[0].children.push(text(' Again'), ref(1), text('.'));
+    const [paragraph] = run(tree).children;
+
+    const notes = paragraph.children.filter(
+      child => child.properties?.className?.[0] === 'margin-note',
+    );
+    expect(notes).toHaveLength(1);
+    expect(paragraph.children.indexOf(notes[0])).toBe(2);
+  });
+
+  it('leaves content without footnotes alone', () => {
+    const tree = { type: 'root', children: [el('p', {}, [text('Hello.')])] };
+    const before = JSON.stringify(tree);
+    run(tree);
+
+    expect(JSON.stringify(tree)).toBe(before);
+  });
+});

--- a/src/@vault/server.js
+++ b/src/@vault/server.js
@@ -13,6 +13,7 @@ import { matter } from 'vfile-matter';
 import rehypeMdxCodeProps from 'rehype-mdx-code-props';
 import NextLink from 'next/link';
 import { cacheLife } from 'next/cache';
+import { rehypeMarginNotes } from './rehype-margin-notes';
 import { ReadingList } from '@reading/server';
 import { Resume } from '@ui/resume';
 import { RecentEssays, ServerEmbed, ServerImage } from '@ui/server';
@@ -147,7 +148,12 @@ export const compile = (/** @type {string} */ source) =>
         }
 
         return (
-          <Link href={props.href.replace('/vault', '').replace('.md', '/')}>
+          // `tabIndex` is forwarded for the margin-note copies: the copy is
+          // `aria-hidden`, so its links stay out of the tab order.
+          <Link
+            href={props.href.replace('/vault', '').replace('.md', '/')}
+            tabIndex={props.tabIndex}
+          >
             {props.children}
           </Link>
         );
@@ -264,7 +270,10 @@ const preComponent = props => {
 const contentMdxOptions = {
   parseFrontmatter: true,
   mdxOptions: {
-    rehypePlugins: [[rehypeMdxCodeProps, { elementAttributeNameCase: 'html' }]],
+    rehypePlugins: [
+      [rehypeMdxCodeProps, { elementAttributeNameCase: 'html' }],
+      rehypeMarginNotes,
+    ],
     remarkPlugins: [remarkGfm],
   },
   blockJS: false,
@@ -273,6 +282,8 @@ const contentMdxOptions = {
 const slideMdxOptions = {
   ...contentMdxOptions,
   mdxOptions: {
+    // Slides inherit `rehypeMarginNotes`, but the CSS is scoped to the article
+    // column, so a footnote in a slide keeps today's behaviour.
     ...contentMdxOptions.mdxOptions,
     remarkPlugins: [
       ...contentMdxOptions.mdxOptions.remarkPlugins,

--- a/src/index.css
+++ b/src/index.css
@@ -176,6 +176,70 @@ pre.prism-code.line-numbers {
   border: 0;
 }
 
+/* Tufte-style margin notes. `rehype-margin-notes` splices an aria-hidden copy
+   of each footnote after its `<sup>`; `float: right` drops that copy at the
+   reference's vertical position for free and `clear: right` makes stacked notes
+   push each other down instead of overlapping — no JS, no measurement.
+
+   Width is fluid off the content column, via a container query since the 352px
+   nav means viewport width overstates the room available. The math assumes that
+   column is `max-w-lg` (800px) with `p-5`, hence the `margin-notes` class
+   `<Main>` puts on it: 800 - 20 + 24 = 804px to the note's left edge, another
+   24px of gutter at the far right. `<Main wide>` is excluded — a float hung off
+   the full-width column would land off the page. */
+.margin-note {
+  display: none;
+}
+
+@media screen {
+  @container (min-width: 1024px) {
+    main.margin-notes .margin-note {
+      /* No lower bound needed: the 1024px gate floors this at 196px. */
+      --margin-note-width: min(calc(100cqi - 828px), 300px);
+      display: block;
+      float: right;
+      clear: right;
+      width: var(--margin-note-width);
+      margin-right: calc(-1 * (var(--margin-note-width) + 24px));
+      /* Padding, not margin: a float only extends scrollable overflow to its
+         border box, so a bottom margin on the last note would be clipped. */
+      padding-bottom: 1.25rem;
+      @apply font-ovo text-sm leading-normal text-darkg;
+    }
+
+    main.margin-notes .margin-note-number {
+      @apply font-muli text-xs text-midg;
+      vertical-align: super;
+      line-height: 1;
+    }
+
+    /* Border-bottom links read as heavy underlines at this size. */
+    main.margin-notes .margin-note a {
+      border-bottom-width: 1px;
+    }
+
+    /* Clipped rather than `display: none`, so the section stays in the
+       accessibility tree as the one real copy of every note and the ref anchors
+       still resolve. `data-margin-notes="all"` is set only when every note in
+       the section made it into the margin: clipping one holding a refused note
+       would leave that note with no visual representation anywhere. */
+    main.margin-notes section[data-footnotes][data-margin-notes='all'] {
+      @apply sr-only;
+    }
+
+    /* Clicking a reference would scroll to a clipped 1x1 target, and the note
+       is already in the margin. Pointer activation only: the anchor keeps its
+       href and tab stop, so keyboard and screen reader users still jump to the
+       real note. Scoped to refs that actually got a copy, since a twice-
+       referenced footnote leaves later refs with nothing beside them. */
+    main.margin-notes:has(section[data-margin-notes='all'])
+      sup:has(+ .margin-note)
+      a[data-footnote-ref] {
+      pointer-events: none;
+    }
+  }
+}
+
 @utility slide-content {
   width: 100vw;
   flex-shrink: 0;


### PR DESCRIPTION
Turns the existing `[^1]` footnotes into Tufte-style margin notes: the note
sits in the right margin at the vertical position of its reference, instead of
at the bottom of the page. No MDX content files change — all 24 footnotes
across 10 files convert automatically.

## How it works

A rehype plugin (`src/@vault/rehype-margin-notes.js`) splices an `aria-hidden`
copy of each footnote in immediately after its `<sup>`, and CSS floats that copy
into the margin.

Float rather than absolute positioning is the whole trick. An inline float lands
at the vertical position of its reference for free, and `clear: right` makes
stacked notes push each other down instead of overlapping — so there is no
measurement, no JavaScript, and nothing to keep in sync on resize. It also
sidesteps the `overflow-y-auto` scroll container in `Layout.js`, which would
have clipped an absolutely positioned note.

The generated `<section data-footnotes>` is left exactly as it was: real ids,
working anchors, and the single copy in the accessibility tree. It is also the
fallback wherever the margin is too narrow, which a **container query on the
article column** decides — not a viewport breakpoint, since the 352px nav means
viewport width badly overstates the room actually left.

## What it looks like

| Viewport | Note width |
|---|---|
| 1512px and up | 300px (capped) |
| 1440px | 260px |
| 1376px | 196px (the floor) |
| 1375px and below | none — footnotes render at the bottom exactly as today |

The article column width is unchanged. `<Main wide>` (the resume) is excluded —
a float hung off the full-width column would land off the page.

## Safety valve

The plugin refuses to copy a note whose body is not phrasing content. A list or
code block spliced into the article's `<p>` would close that paragraph in the
parser and restructure the DOM out from under React. Such a note keeps its place
at the bottom of the page, and its whole section stays visible rather than
clipped, so no note ends up with no visual representation anywhere.

## Verification

- `npm test` green: 19 tests, including 12 new unit tests covering double
  references, multi-paragraph bodies, list bodies, unreferenced definitions,
  undefined references, and MDX nodes in note bodies.
- No new dependency. `unist-util-visit` was the approved option, but the walk it
  needs is a dozen lines, so `eachElement` in the plugin does it in-file rather
  than promoting a transitive package to a direct dependency. Worth a look if
  you would rather take the dep.
- Rendered and inspected at 1728 / 1512 / 1440 / 1376 / 1375 / 1280 / 768 /
  390px across all 10 footnote pages: notes land at their markers, never overlap
  or clip, no horizontal scrollbar at any width, and the hand-off to the
  bottom-of-page section is atomic — no width shows both or neither.
- Console is clean. The invalid-nesting errors on the `that-shirt` page are
  pre-existing tweet embeds; no margin note is involved.

## Known tradeoffs

- The note text is in the DOM twice (margin copy + real section), so find-in-page
  matches each note twice and select-all yields it twice. Inherent to the CSS-only
  approach; the accessibility tree stays clean.
- A long note at the very end of an article extends the scroll container past the
  text, leaving a blank band. The note is not clipped, which is the part that
  matters.
- `src/@ui/box/Main.js` picks up a `margin-notes` class. The column width itself is
  untouched, as agreed — the class is what excludes the wide resume column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)