### PR TITLE
Stop generating an invalid print media query

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,10 @@
  */
 @config '../tailwind.config.cjs';
 
+/* Nothing here uses the `container` utility. The scanner matches it out of
+   `containerRef` and `@container`, so block the candidate outright. */
+@source not inline("container");
+
 /*
   The default border color has changed to `currentcolor` in Tailwind CSS v4,
   so we've added these compatibility styles to make sure everything still

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -27,7 +27,6 @@ module.exports = {
       lg: '768px',
       xl: '992px',
       '2xl': '1120px',
-      print: { raw: 'print' },
     },
     fontFamily: {
       muli: ['var(--font-mulish)', ...fontFamily.sans],


### PR DESCRIPTION
Every build has emitted this warning, on `main` as much as on any branch:

```
Turbopack build encountered 1 warning:
./src/index.css:2:6004
Warning: Parsing CSS source code failed
...container{width:100%}@media (min-width:print){.container{max-width:print}}...
                                                ^
Invalid media query
```

Two independent things had to be true for it to appear, so this fixes both.

## The invalid rule

`tailwind.config.cjs` declared `print: { raw: 'print' }` in `screens`. Tailwind v4
converts legacy `screens` entries into `--breakpoint-*` values, and the compat
`container` utility emits one `max-width` block per breakpoint — with no notion
that a `raw` entry is a media query rather than a width. The raw string landed on
both sides of a width comparison:

```css
.container {
  width: 100%;
  @media (width >= print) { max-width: print; }   /* ← this */
  @media (width >= 320px) { max-width: 320px; }
```

The custom screen was redundant: **Tailwind v4 has a built-in `print` variant.**
Removing it leaves all 24 `print:` utilities (45 occurrences across `src/`) and
all 26 `@media print` blocks byte-identical in the generated CSS.

## Why `.container` existed at all

Nothing in this project uses the `container` class. Tailwind's scanner extracts
candidates from raw source text, and `container` appears inside `containerRef` in
`src/@ui/components/Talk.js` and `@container` in `src/@ui/layout/Layout.js`. So a
rule nobody asked for — plus seven dead breakpoint blocks — has been shipping to
every visitor for as long as that variable has existed.

`@source not inline("container")` blocks the candidate outright, which is sturdier
than renaming variables to dodge a substring match.

## Verification

- **Warning gone.** `npm run build` before: `Turbopack build encountered 1 warning`.
  After: no match for "Invalid media query", and no new warning replaced it.
- **`.container` rules: 1 → 0**, confirmed by compiling `src/index.css` through
  `@tailwindcss/postcss` directly.
- **Print output unchanged.** `/resume` printed to PDF before and after and
  rasterized at 100dpi: all 3 pages byte-identical. Screen rendering byte-identical
  too. Generated CSS still has 25 `print:` utilities and 26 `@media print` blocks.
- `npm test` passes; prettier and eslint clean.

Note that `npm run build` still fails locally afterward on `ETIMEDOUT` during static
export, because there is no `.env` to fetch remote content with. That is pre-existing
and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)